### PR TITLE
Add some governance docs that were in guac repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+All community members must abide by the [OpenSSF Code of
+Conduct](https://openssf.org/community/code-of-conduct/).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,69 @@
+# Governance
+
+## License
+
+The project will use [Apache 2.0 license](LICENSE) for code. To start, the
+project will not be under any foundation, and does not have immediate plans to
+do so. However, this may change in the future.
+
+## Maintainership
+
+List of maintainers can be found at [MAINTAINERS](MAINTAINERS).
+
+Maintainership is driven by engineering contributions to the project, and a n-1
+vote among current maintainers is required to make changes to the list of
+maintainers. Should the quorum of necessary maintainers to merge changes be
+unmet due to a maintainer’s inactivity for 3 months — without prior notice and
+concurrence to the absence — the inactive maintainer will be removed from the
+project and the decision documented.
+
+At any one time, there should be at least 3 maintainers.
+
+## Code of Conduct
+
+Please refer to the [Code of Conduct](CODE_OF_CONDUCT.md) for full details.
+
+## Technical Advisory Members
+
+Due to the nature of the project aiming to establish a common knowledge graph
+representation, the project will also have a set of “Technical Advisory
+Members”.
+
+Technical Advisory Members provide input into the project, to assist in
+providing maintainers of the project with information that can help lead to more
+informed decisions and thus, a more successful project. It is noted that
+Technical Advisory Members’ main purpose is to inform, and the project
+maintainers will shape its direction, work items and roadmap as they best
+determine based on the advice provided.
+
+Logistics
+
+- Members will be part of a mailing list that will contain updates from the
+  project
+- Members will provide feedback directly to the mailing list or to project
+  maintainers directly in the approved communication medium to ensure all
+  parties are informed
+- Membership has no term as long as there is relevance to the project
+- Members, and their companies (by choice), will be listed on the project page
+  and contributions acknowledged
+- During significant milestones, or quarterly (whichever comes first), an
+  optional meeting/demo will be hosted with invitations to members,
+
+Responsibilities
+
+- Provide feedback to the project on relevant use cases that should be
+  considered in the project
+- Provide feedback to the project especially in regards to technical direction
+  and emerging technologies
+- Provide recommendations for additional Technical Advisory Members
+
+Technical Advisory Membership is provided by:
+
+- Directly by invitation of project maintainers
+- Approved recommendations by other members
+- If members are seen to act disruptively, they may be given warnings of their
+  disruptive actions, with up to two warnings. Disruptive behavior
+- Upon the 3rd occurance of disruptive behavior, membership may be removed by
+  unanimous vote by maintainers
+- Members who are found to be threatening and malicious, e.g. active harassment
+  will be removed immediately with vote by 2 maintainers

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,9 +2,7 @@
 
 ## License
 
-The project will use [Apache 2.0 license](LICENSE) for code. To start, the
-project will not be under any foundation, and does not have immediate plans to
-do so. However, this may change in the future.
+The project will use [Apache 2.0 license](LICENSE) for code.
 
 ## Maintainership
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,11 @@
+# GUAC project maintainers
+#
+# See GOVERNANCE.md
+#
+# GitHub ID, Name, Affiliation, Email address
+"mlieberman85", "Michael Lieberman", "Kusari", "mike@kusari.dev"
+"mihaimaruseac", "Mihai Maruseac", "Google", "mihaimaruseac@google.com"
+"lumjjb", "Brandon Lum", "Google", "lumb@google.com"
+"pxp928", "Parth Patel", "Kusari", "parth@kusari.dev"
+"SantiagoTorres", "Santiago Torres", "Purdue University", "santiagotorres@purdue.edu"
+"jeffmendoza", "Jeff Mendoza", "Kusari", "jlm@jlm.name"


### PR DESCRIPTION
This is a follow on to notes from last week's [Supply Chain Integrity WG meeting](https://docs.google.com/document/d/1moVFPn5pLi-uGs840_YBCrwdpHajU0ptFmlL4F9GryQ/edit?tab=t.0#heading=h.u9ozr53s1z0) where it was not obvious in the GUAC repo that the charter exists here. While I'm updating the README over there to address that, I figured now's a good time to move some of the governance docs into the governance repo. 

Signed-off-by: Ben Cotton <ben@kusari.dev>